### PR TITLE
Fix building OS image on Ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ CARD ?= /dev/mmcblk0
 
 
 # =====
+SHELL = /bin/bash
 _BUILDER_DIR = ./.pi-builder
 
 define fetch_version


### PR DESCRIPTION
At least one cp command in the Makefile requires brace expansion. The default shell is `/bin/bash`.

This fixes following error:
```bash
user@localhost:~/os$ make os
rm -rf ./.pi-builder/stages/{pikvm,pikvm-otg-console}
cp -a {pikvm,pikvm-otg-console} ./.pi-builder/stages
cp: cannot stat '{pikvm,pikvm-otg-console}': No such file or directory
Makefile:49: recipe for target 'os' failed
make: *** [os] Error 1
```