### PR TITLE
Fix Makefile to work on systems w/o /bin/bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ CARD ?= /dev/mmcblk0
 
 
 # =====
-SHELL = /bin/bash
+SHELL = /usr/bin/env bash
 _BUILDER_DIR = ./.pi-builder
 
 define fetch_version


### PR DESCRIPTION
/usr/bin/env bash is more reliable way of finding bash
example: NixOS