### PR TITLE
Create pi.yml

### DIFF
--- a/.github/workflows/pi.yml
+++ b/.github/workflows/pi.yml
@@ -1,0 +1,17 @@
+name: pikvm-os
+
+on: [push, pull_request]
+
+jobs:
+  os:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        
+      - name: os
+        run: make os
+        
+      - name: image
+        run: make image
+    


### PR DESCRIPTION
Merge this after merging:

https://github.com/pikvm/pi-builder/pull/3

The above PR just makes pi-builder compatible with Github Actions.  Then `os` can run here, and we can even do matrix builds.  