### PR TITLE
Support of alternative boards/SBCs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ REPO_URL ?= http://de3.mirror.archlinuxarm.org
 BUILD_OPTS ?=
 BUILDER_URL ?= https://github.com/mdevaev/pi-builder
 PIKVM_REPO_URL ?= https://pikvm.org/repos
+PIKVM_REPO_KEY ?= 912C773ABBD1B584
 
 WIFI_ESSID ?=
 WIFI_PASSWD ?=
@@ -75,7 +76,9 @@ os: $(_BUILDER_DIR)
 		HOSTNAME=$(HOSTNAME) \
 		LOCALE=$(LOCALE) \
 		TIMEZONE=$(TIMEZONE) \
-		REPO_URL=$(REPO_URL)
+		REPO_URL=$(REPO_URL) \
+		PIKVM_REPO_URL=$(PIKVM_REPO_URL) \
+		PIKVM_REPO_KEY=$(PIKVM_REPO_KEY)
 
 
 $(_BUILDER_DIR):

--- a/Makefile
+++ b/Makefile
@@ -121,10 +121,10 @@ image:
 	sudo bash -x -c ' \
 		dd if=/dev/zero of=$(IMAGE_FILE) bs=512 count=12582912 \
 		&& device=`losetup --find --show $(IMAGE_FILE)` \
-		&& make install CARD=$$device \
+		&& make install CARD=$$device BOARD=$(BOARD) ARCH=$(ARCH) UBOOT=$(UBOOT)\
 		&& losetup -d $$device \
 	'
-	bzip2 $(IMAGE_FILE)
+	bzip2 -f $(IMAGE_FILE)
 	sha1sum $(IMAGE_FILE).bz2 | awk '{print $$1}' > $(IMAGE_FILE).bz2.sha1
 
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 BOARD ?= rpi4
 ARCH ?= arm
 PLATFORM ?= v2-hdmi
+UBOOT ?=
 STAGES ?= __init__ os pikvm-repo watchdog ro no-audit pikvm pikvm-image __cleanup__
 
 HOSTNAME ?= pikvm
@@ -72,6 +73,7 @@ os: $(_BUILDER_DIR)
 		PROJECT=pikvm-os-$(PLATFORM) \
 		BOARD=$(BOARD) \
 		ARCH=$(ARCH) \
+		BOOT=$(BOOT) \
 		STAGES='$(STAGES)' \
 		HOSTNAME=$(HOSTNAME) \
 		LOCALE=$(LOCALE) \
@@ -95,6 +97,7 @@ install: $(_BUILDER_DIR)
 		CARD=$(CARD) \
 		BOARD=$(BOARD) \
 		ARCH=$(ARCH) \
+		BOOT=$(BOOT) \
 		CARD_DATA_FS_TYPE=$(if $(findstring v2-hdmi,$(PLATFORM)),ext4,) \
 		CARD_DATA_FS_FLAGS=-m0
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ WEBUI_ADMIN_PASSWD ?= admin
 IPMI_ADMIN_PASSWD ?= admin
 
 CARD ?= /dev/mmcblk0
+IMAGE_FILE ?= images/$(PLATFORM)-$(BOARD)-$(ARCH)$(if $(UBOOT),-$(UBOOT),).img
 
 
 # =====
@@ -73,7 +74,7 @@ os: $(_BUILDER_DIR)
 		PROJECT=pikvm-os-$(PLATFORM) \
 		BOARD=$(BOARD) \
 		ARCH=$(ARCH) \
-		BOOT=$(BOOT) \
+		UBOOT=$(UBOOT) \
 		STAGES='$(STAGES)' \
 		HOSTNAME=$(HOSTNAME) \
 		LOCALE=$(LOCALE) \
@@ -97,7 +98,7 @@ install: $(_BUILDER_DIR)
 		CARD=$(CARD) \
 		BOARD=$(BOARD) \
 		ARCH=$(ARCH) \
-		BOOT=$(BOOT) \
+		UBOOT=$(UBOOT) \
 		CARD_DATA_FS_TYPE=$(if $(findstring v2-hdmi,$(PLATFORM)),ext4,) \
 		CARD_DATA_FS_FLAGS=-m0
 
@@ -118,13 +119,13 @@ clean-all:
 image:
 	mkdir -p images
 	sudo bash -x -c ' \
-		dd if=/dev/zero of=images/$(PLATFORM)-$(BOARD)-$(ARCH).img bs=512 count=12582912 \
-		&& device=`losetup --find --show images/$(PLATFORM)-$(BOARD)-$(ARCH).img` \
+		dd if=/dev/zero of=$(IMAGE_FILE) bs=512 count=12582912 \
+		&& device=`losetup --find --show $(IMAGE_FILE)` \
 		&& make install CARD=$$device \
 		&& losetup -d $$device \
 	'
-	bzip2 images/$(PLATFORM)-$(BOARD)-$(ARCH).img
-	sha1sum images/$(PLATFORM)-$(BOARD)-$(ARCH).img.bz2 | awk '{print $$1}' > images/$(PLATFORM)-$(BOARD)-$(ARCH).img.bz2.sha1
+	bzip2 $(IMAGE_FILE)
+	sha1sum $(IMAGE_FILE).bz2 | awk '{print $$1}' > $(IMAGE_FILE).bz2.sha1
 
 
 upload:

--- a/pikvm-image/Dockerfile.part
+++ b/pikvm-image/Dockerfile.part
@@ -3,3 +3,9 @@ RUN rm -f /etc/ssh/ssh_host_* /etc/kvmd/nginx/ssl/*
 COPY stages/pikvm-image/_pikvm-firstboot.sh /usr/local/bin/_pikvm-firstboot.sh
 COPY stages/pikvm-image/pikvm-firstboot.service /etc/systemd/system/pikvm-firstboot.service
 RUN systemctl enable pikvm-firstboot
+
+# https://archlinuxarm.org/platforms/armv8/broadcom/raspberry-pi-4#installation
+RUN [ "$BOARD-$ARCH" != "rpi4-aarch64" ] || ( \
+		sed -i 's/mmcblk0/mmcblk1/g' /etc/fstab \
+		&& sed -i 's/mmcblk0/mmcblk1/g' /usr/local/bin/_pikvm-firstboot.sh \
+	)

--- a/pikvm/Dockerfile.part
+++ b/pikvm/Dockerfile.part
@@ -30,7 +30,8 @@ RUN systemctl enable kvmd \
 COPY stages/pikvm/motd /etc/
 
 RUN [ ! -f /boot/cmdline.txt ] || sed -i -f /usr/share/kvmd/configs.default/os/cmdline/$PLATFORM-$BOARD.sed /boot/cmdline.txt \
-	&& cp /usr/share/kvmd/configs.default/os/boot-config/$PLATFORM-$BOARD.txt /boot/config.txt
+	&& [ ! -f /usr/share/kvmd/configs.default/os/boot-config/$PLATFORM-$BOARD.txt ] \
+		|| cp /usr/share/kvmd/configs.default/os/boot-config/$PLATFORM-$BOARD.txt /boot/config.txt
 
 RUN sed -i -e "s/-session   optional   pam_systemd.so/#-session   optional   pam_systemd.so/g" /etc/pam.d/system-login
 

--- a/pikvm/Dockerfile.part
+++ b/pikvm/Dockerfile.part
@@ -24,8 +24,11 @@ RUN systemctl enable kvmd \
 
 COPY stages/pikvm/motd /etc/
 
-RUN sed -i -f /usr/share/kvmd/configs.default/os/cmdline/$PLATFORM-$BOARD.sed /boot/cmdline.txt \
+RUN [ ! -f /boot/cmdline.txt ] || sed -i -f /usr/share/kvmd/configs.default/os/cmdline/$PLATFORM-$BOARD.sed /boot/cmdline.txt \
 	&& cp /usr/share/kvmd/configs.default/os/boot-config/$PLATFORM-$BOARD.txt /boot/config.txt
+
+COPY stages/pikvm/vcgencmd /tmp/	
+RUN [ -f /opt/vc/bin/vcgencmd ] || ( mkdir -p /opt/vc/bin && cp -a /tmp/vcgencmd /opt/vc/bin/vcgencmd )
 
 RUN sed -i -e "s/-session   optional   pam_systemd.so/#-session   optional   pam_systemd.so/g" /etc/pam.d/system-login
 

--- a/pikvm/Dockerfile.part
+++ b/pikvm/Dockerfile.part
@@ -12,6 +12,11 @@ RUN pkg-install \
 	parted \
 	e2fsprogs
 
+RUN [ "$BOARD-$ARCH" != "rpi4-aarch64" ] || pkg-install raspberrypi-userland-aarch64
+
+COPY stages/pikvm/vcgencmd /tmp/
+RUN [ -f /opt/vc/bin/vcgencmd ] || ( mkdir -p /opt/vc/bin && cp -a /tmp/vcgencmd /opt/vc/bin/vcgencmd )
+
 RUN systemctl enable kvmd \
 	&& systemctl enable kvmd-nginx \
 	&& systemctl enable kvmd-webterm \
@@ -26,9 +31,6 @@ COPY stages/pikvm/motd /etc/
 
 RUN [ ! -f /boot/cmdline.txt ] || sed -i -f /usr/share/kvmd/configs.default/os/cmdline/$PLATFORM-$BOARD.sed /boot/cmdline.txt \
 	&& cp /usr/share/kvmd/configs.default/os/boot-config/$PLATFORM-$BOARD.txt /boot/config.txt
-
-COPY stages/pikvm/vcgencmd /tmp/	
-RUN [ -f /opt/vc/bin/vcgencmd ] || ( mkdir -p /opt/vc/bin && cp -a /tmp/vcgencmd /opt/vc/bin/vcgencmd )
 
 RUN sed -i -e "s/-session   optional   pam_systemd.so/#-session   optional   pam_systemd.so/g" /etc/pam.d/system-login
 

--- a/pikvm/vcgencmd
+++ b/pikvm/vcgencmd
@@ -1,0 +1,67 @@
+#!/bin/sh
+# try and keep this pure bourne shell
+# minimal clone of raspberry tool vcgencmd - for use with Android rpicheck and rock64 SBC
+
+command=$1
+case ${1} in
+        measure_clock)
+                case ${2} in
+                        arm)
+                                # awk is probably overkill....
+				value=`cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq | awk '{print $1 * 1000}'`
+                                echo 'frequency(45)='${value}
+                                exit
+                        ;;
+                        core)
+                                value=0  # TODO / FIXME
+                                echo 'frequency(1)='${value}
+                                exit
+                        ;;
+                # TODO anything else thrown an error/debug
+                esac
+                exit
+                ;;
+        measure_temp)
+                # awk is probably overkill....
+                value=`cat /sys/class/thermal/thermal_zone0/temp | awk '{print $1 / 1000}'`
+                echo 'temp='${value}"'C"
+                exit
+                ;;
+        measure_volts)
+                case ${2} in
+                        core)
+                                value=1  # TODO / FIXME
+                                echo 'volt='${value}'.0000V'
+                                exit
+                        ;;
+                # TODO anything else thrown an error/debug
+                esac
+                ;;
+	get_throttled)
+		echo 'throttled=0x00000'
+		exit
+		;;                
+        version)
+                echo 'Nov  4 2018 16:31:07'
+                echo 'Copyright (c) 2012 rock64'
+                echo 'version rock64_TODO (clean) (release)'
+                exit
+                ;;
+esac
+
+
+exit
+# remove/comment out exit about for debug logging
+
+# if we got here, unrecognized parameter
+# log it for debugging purposes
+
+# on this device /var/log is ramfs folder2ram
+LOG=/var/log/vcgencmd.log
+LOG=/tmp/vcgencmd.log
+
+
+date >> ${LOG}
+echo PARAM ${*} PARAM >> ${LOG}
+echo '=============' >> ${LOG}
+

--- a/pikvm/vcgencmd
+++ b/pikvm/vcgencmd
@@ -51,17 +51,4 @@ esac
 
 
 exit
-# remove/comment out exit about for debug logging
-
-# if we got here, unrecognized parameter
-# log it for debugging purposes
-
-# on this device /var/log is ramfs folder2ram
-LOG=/var/log/vcgencmd.log
-LOG=/tmp/vcgencmd.log
-
-
-date >> ${LOG}
-echo PARAM ${*} PARAM >> ${LOG}
-echo '=============' >> ${LOG}
 


### PR DESCRIPTION
This enables building PI-KVM on boards other than Raspberry Pi.
Currently works on Rock64, Libretech ALL-H3-CC and Orange Pi One/Zero (untested) with v2-hdmiusb configuration. 
Other SBCs supported by mainline kernel and u-boot can be easily added.

Major changes:
 - Added new "generic" board and corresponding kvmd platform configuration that has been stripped out of Raspberry Pi dependencies.
 - Support for aarch64 builds. New ARCH parameter for selecting the architecture (arm/aarch64).
 - Automated building and installation of U-Boot from source. U-Boot configuration can be set by UBOOT parameter. Boot scripts have been updated to switch USB OTG into peripheral mode. Single "os" build can be installed with different U-BOOT images.
 - Makefile parameters for overriding repo URL and keys. Makes it possible to build the entire thing locally.
 
 Some build instructions and sample board configurations are here: https://github.com/Yura80/pikvm-rock64