### PR TITLE
Corrected quoting in Makefile so make will add proper quotes where ne…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ os: $(_BUILDER_DIR)
 		' \
 		PROJECT=pikvm-os-$(PLATFORM) \
 		BOARD=$(BOARD) \
-		STAGES=$(STAGES) \
+		STAGES='$(STAGES)' \
 		HOSTNAME=$(HOSTNAME) \
 		LOCALE=$(LOCALE) \
 		TIMEZONE=$(TIMEZONE) \

--- a/Makefile
+++ b/Makefile
@@ -53,22 +53,22 @@ os: $(_BUILDER_DIR)
 	cp -a pikvm pikvm-image pikvm-otg-console $(_BUILDER_DIR)/stages
 	make -C $(_BUILDER_DIR) os \
 		NC=$(NC) \
-		BUILD_OPTS=" $(BUILD_OPTS) \
+		BUILD_OPTS=' $(BUILD_OPTS) \
 			--build-arg PLATFORM=$(PLATFORM) \
 			--build-arg USTREAMER_VERSION=$(call fetch_version,ustreamer) \
 			--build-arg KVMD_VERSION=$(call fetch_version,kvmd) \
 			--build-arg KVMD_WEBTERM_VERSION=$(call fetch_version,kvmd-webterm) \
-			--build-arg WIFI_ESSID='$(WIFI_ESSID)' \
-			--build-arg WIFI_PASSWD='$(WIFI_PASSWD)' \
-			--build-arg WIFI_IFACE='$(WIFI_IFACE)' \
-			--build-arg ROOT_PASSWD='$(ROOT_PASSWD)' \
-			--build-arg WEBUI_ADMIN_PASSWD='$(WEBUI_ADMIN_PASSWD)' \
-			--build-arg IPMI_ADMIN_PASSWD='$(IPMI_ADMIN_PASSWD)' \
+			--build-arg WIFI_ESSID=$(WIFI_ESSID) \
+			--build-arg WIFI_PASSWD=$(WIFI_PASSWD) \
+			--build-arg WIFI_IFACE=$(WIFI_IFACE) \
+			--build-arg ROOT_PASSWD=$(ROOT_PASSWD) \
+			--build-arg WEBUI_ADMIN_PASSWD=$(WEBUI_ADMIN_PASSWD) \
+			--build-arg IPMI_ADMIN_PASSWD=$(IPMI_ADMIN_PASSWD) \
 			--build-arg NEW_HTTPS_CERT=$(shell uuidgen) \
-		" \
+		' \
 		PROJECT=pikvm-os-$(PLATFORM) \
 		BOARD=$(BOARD) \
-		STAGES='$(STAGES)' \
+		STAGES=$(STAGES) \
 		HOSTNAME=$(HOSTNAME) \
 		LOCALE=$(LOCALE) \
 		TIMEZONE=$(TIMEZONE) \


### PR DESCRIPTION
Make was treating the `"` characters in `config.mk` as part of the string so it interacted with the outer quotes of the `make` command in the `os` target causing the quotes to be stripped and spaces to be laid bare. The single quotes (`'` ) did not resolve the issue because `make` treats these as character literals without special meaning.

Changing the outer quotes from `"` to `'` has no effect on variable expansion with `make` and was necessary to prevent Bash from stripping the quotes in the subshell after removing other quotes that would interact negatively. This allows users to use double quotes (`"`) around variables in the `config.mk` file that contain spaces and some other characters that Bash may interpret though other characters, such as `$`, `"`, and `\` will still need to be escaped as `\$`, `\"`, and `\\` if present as `make` does not include a function to escape special characters automatically.
