### PR TITLE
Fix wireless drops with regulatory domain

### DIFF
--- a/pikvm-image/_pikvm-bootconfig.sh
+++ b/pikvm-image/_pikvm-bootconfig.sh
@@ -26,6 +26,14 @@ if [ -n "$FIRSTBOOT" ]; then
 	fi
 fi
 
+# Set the regulatory domain for wifi, if defined.
+if [ -n "${WIRELESS_REGDOM}" ]; then
+	sed --in-place --expression 's/^\(WIRELESS_REGDOM=.*\)$/#\1/' \
+		--expression 's/^#\(WIRELESS_REGDOM="'$REGDOM'"\)/\1/' \
+		/etc/conf.d/wireless-regdom
+fi
+
+# If the WIFI_ESSID is defined, configure wlan0
 if [ -n "$WIFI_ESSID" ]; then
 	WIFI_IFACE="${WIFI_IFACE:-wlan0}"
 	_config="/etc/netctl/$WIFI_IFACE-${WIFI_ESSID/ /_}"

--- a/pikvm-image/_pikvm-bootconfig.sh
+++ b/pikvm-image/_pikvm-bootconfig.sh
@@ -29,7 +29,7 @@ fi
 # Set the regulatory domain for wifi, if defined.
 if [ -n "${WIRELESS_REGDOM}" ]; then
 	sed --in-place --expression 's/^\(WIRELESS_REGDOM=.*\)$/#\1/' \
-		--expression 's/^#\(WIRELESS_REGDOM="'$REGDOM'"\)/\1/' \
+		--expression 's/^#\(WIRELESS_REGDOM="'$WIRELESS_REGDOM'"\)/\1/' \
 		/etc/conf.d/wireless-regdom
 fi
 


### PR DESCRIPTION
Add `WIRELESS_REGDOM` option to set the wireless regulatory domain on first boot. By default, all regions should be commented out in `/etc/conf.d/wireless-regdom`, permitting only a limited number of spectrums, bandwidths, and channels common to all regions. This may result in non-optimal channel selections, poor signal strength, and connection drops.

The patch will ensure only the matching `WIRELESS_REGDOM="{ISO 3166-1 alpha-2 Country Code}"` is uncommented. It is recommended users ensure their country code is in the regulatory domain list, if it does not match no lines will be uncommented, even if one was previously uncommented.

See https://wiki.archlinux.org/index.php/Network_configuration/Wireless#Tips_and_tricks for more information.

Fixes https://github.com/pikvm/os/issues/11