### PR TITLE
Add IP to console banner

### DIFF
--- a/pikvm/Dockerfile.part
+++ b/pikvm/Dockerfile.part
@@ -27,6 +27,7 @@ RUN systemctl enable kvmd \
 	))
 
 COPY stages/pikvm/motd /etc/
+COPY stages/pikvm/issue /etc/
 
 RUN sed -i -f /usr/share/kvmd/configs.default/os/cmdline/$PLATFORM-$BOARD.sed /boot/cmdline.txt \
 	&& cp /usr/share/kvmd/configs.default/os/boot-config/$PLATFORM-$BOARD.txt /boot/config.txt

--- a/pikvm/issue
+++ b/pikvm/issue
@@ -1,0 +1,3 @@
+Welcome to Pi-KVM - Open Source IP-KVM based on Raspberry Pi
+\S \r (\l)
+IP: \4


### PR DESCRIPTION
Add an /etc/issue with the default text from Arch, plus some pikvm
explanatory text from motd, plus the IP address of the first fully
configured network interface.

This is useful for being able to immediately see the IP that the device
has been assigned to more quickly get to the web interface as long as
someone is able to plug it into a monitor. This is more convenient than
logging into the device because the device might be in OTG mode and
unable to accept keyboard input.

Example output:

```
Welcome to Pi-KVM - Open Source IP-KVM based on Raspberry Pi
Arch Linux ARM 5.10.14-3-ARCH (tty1)
IP: 192.168.1.179
```