### PR TITLE
Fix mount is busy when switching rw to ro mode.

### DIFF
--- a/pikvm/Dockerfile.part
+++ b/pikvm/Dockerfile.part
@@ -42,6 +42,8 @@ RUN systemctl enable kvmd \
 		&& echo "/dev/mmcblk0p3 /var/lib/kvmd/msd  ext4  nodev,nosuid,noexec,ro,errors=remount-ro,data=journal,X-kvmd.otgmsd-root=/var/lib/kvmd/msd,X-kvmd.otgmsd-user=kvmd  0 0" >> /etc/fstab \
 	))
 
+RUN echo "tmpfs /var/lib/dhclient  tmpfs  mode=0700 0 0" >> /etc/fstab
+	
 COPY stages/pikvm/motd /etc/
 COPY stages/pikvm/issue /etc/
 


### PR DESCRIPTION
This is due to dhclient locking the root filesystem, So use tmpfs instead.