### PR TITLE
Remove data=journal from /etc/fstab

### DIFF
--- a/pikvm/Dockerfile.part
+++ b/pikvm/Dockerfile.part
@@ -38,7 +38,7 @@ RUN pkg-install --assume-installed tessdata \
 	hostapd \
 	edid-decode
 
-ENV PART_OPTS nodev,nosuid,noexec,ro,errors=remount-ro,data=journal
+ENV PART_OPTS nodev,nosuid,noexec,ro,errors=remount-ro
 RUN echo "LABEL=PIPST /var/lib/kvmd/pst  ext4  $PART_OPTS,X-kvmd.pst-user=kvmd-pst  0 0" >> /etc/fstab
 RUN systemctl enable kvmd-bootconfig \
 	&& systemctl enable kvmd \


### PR DESCRIPTION
Data journaling mode from ext4 writes the data twice - in the journal and non-journal area - for enhanced integrity.

While this may be acceptable for PST (Persistent storage), this is an overkill for MSD (Mass Storage Drive) and leads to much slower writes.

Even for PST, this is an overkill for the following reasons:
 - The regular root drive is not using data journal mode, where integrity matters the most.
 - The dirty writeback policies of pikvm makes it extremely unlikely for a data corruption to occur.

Switch to the ext4's default journaling mode, data=ordered, which journals metadata.