### PR TITLE
remove kvmd-oled dependency since its part of kvmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ os: $(_BUILDER_DIR)
 	$(MAKE) -C $(_BUILDER_DIR) os \
 		BUILD_OPTS=' $(BUILD_OPTS) \
 			--build-arg PLATFORM=$(PLATFORM) \
-			--build-arg VERSIONS=$(call fv,ustreamer)/$(call fv,kvmd)/$(call fv,kvmd-webterm)/$(call fv,kvmd-oled)/$(call fv,kvmd-fan) \
 			--build-arg OLED=$(call optbool,$(OLED)) \
+			--build-arg VERSIONS=$(call fv,ustreamer)/$(call fv,kvmd)/$(call fv,kvmd-webterm)/$(call fv,kvmd-fan) \
 			--build-arg FAN=$(call optbool,$(FAN)) \
 			--build-arg ROOT_PASSWD=$(ROOT_PASSWD) \
 			--build-arg WEBUI_ADMIN_PASSWD=$(WEBUI_ADMIN_PASSWD) \

--- a/stages/arch/pikvm/Dockerfile.part
+++ b/stages/arch/pikvm/Dockerfile.part
@@ -21,7 +21,6 @@ RUN pacman --noconfirm --ask=4 -Syu \
 RUN pkg-install --assume-installed tessdata \
 		kvmd-platform-$PLATFORM-$BOARD \
 		kvmd-webterm \
-		kvmd-oled \
 		kvmd-fan \
 		tesseract \
 		tesseract-data-eng \


### PR DESCRIPTION
https://github.com/pikvm/packages/commit/2a670b3628474b31e176c294945eec05af960dc2

Without this change, the image can't be build at the moment.